### PR TITLE
- Breaking change (minor): `catch` to be passed error event, not erro…

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,13 @@
+##
+
+* Breaking change (minor): `catch` to be passed error event, not error object
+* Fix: Remove repeated attempt after block event as not working in browser testing
+* Fix: Polyfill delete's `newVersion` for Firefox
+* Fix: Polyfill PhantomJS' `del` success event, resumed and otherwise
+* Fix: `preventDefault` within error handlers to avoid bubbling of errors beyond `catch`
+* Feature: Support resumption of blocked events via `resume` property
+* Feature: Pass on event object to `del` `onsuccess`
+
 ## 1.0.0 / 2015-11-28
 
 * initial release :sparkles:

--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@
 
 This module provides consistent, modern API to `window.indexedDB`.
 It's especially useful for test environment, when you need to open/delete database multiple times.
-For implementation details check [just 100 lines of the source](./src/index.js).
+For implementation details see the [150 lines of the source](./src/index.js).
 
 ## Example
 
@@ -33,7 +33,8 @@ function upgradeCallback(e) {
 
 ## API
 
-`open` and `del` return `Promise` and handle `blocked` event by repeating operation after 100ms.
+`open` and `del` each return a `Promise`. See the section on blocking
+events for more details.
 
 ### open(dbName, [version], [upgradeCallback])
 
@@ -84,6 +85,13 @@ await deleteDatabase('mydb') // delete database by name
 })();
 ```
 
+Note that due to a [browser bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1220279)
+the `oldVersion` property of `del` error events does not work properly in
+Firefox, but we have at least polyfilled its problem with `newVersion`
+(which should be `null`).
+
+We've similarly polyfilled its `success` event (for the sake of PhantomJS).
+
 ### cmp(val1, val2)
 
 ```js
@@ -128,6 +136,31 @@ if (isSafari8) {
 const db = await open('mydb')
 
 })();
+```
+
+### Blocking events
+
+Genuine `blocked` events (as with errors) can be caught, and `blocked` event
+objects will also be assigned a custom `resume` property promise which can be
+used similarly to the original `open` (or `del`) call (upon successful closing
+of all other open connections).
+
+```js
+import { del as deleteDatabase } from 'idb-factory'
+try {
+  async deleteDatabase('mydb') // delete database by name
+} catch (err) {
+  if (err.type !== 'blocked') {
+    // Handle other `err` errors here
+    return
+  }
+  closeOpenConnections()
+  try {
+    async err.resume
+  } catch (err) {
+    // Handle errors upon resumption
+  }
+}
 ```
 
 ## LICENSE

--- a/test/index.js
+++ b/test/index.js
@@ -4,8 +4,9 @@ import { expect } from 'chai'
 import { open, del, cmp } from '../src'
 import * as idbFactory from '../src'
 
-describe('idb-factory', () => {
+describe('idb-factory', function idbFactoryTests() {
   ES6Promise.polyfill()
+  this.timeout(5000)
   const dbName = 'idb-factory'
 
   before(() => del(dbName))
@@ -35,9 +36,57 @@ describe('idb-factory', () => {
     })
   })
 
+  it('deletes db', () => {
+    return open(dbName, 3, upgradeCallback).then((db1) => {
+      db1.close()
+      return del(dbName).then((e) => {
+        // expect(e.oldVersion).equal(3) // Won't work in PhantomJS: https://github.com/ariya/phantomjs/issues/14141
+        expect(e.newVersion).to.be.a('null')
+      })
+    })
+  })
+
   it('compares 2 values', () => {
     expect(cmp(1, 5)).equal(-1)
     expect(cmp('z', 'a')).equal(1)
+  })
+
+  it('resumes from a genuine blocked event via resume property on open', () => {
+    let caught = false
+    return open(dbName, 3, upgradeCallback).then((db1) => {
+      return open(dbName, 4).catch(function errorCatcher(err) {
+        if (err.type === 'blocked') {
+          // Handle other `err` errors here
+          db1.close()
+          caught = true
+          return err.resume
+        }
+      }).then(function completedOpen(db2) {
+        db2.close()
+        expect(caught).equal(true)
+        return del(dbName)
+      })
+    })
+  })
+
+  it('resumes from a genuine blocked event via resume property on del (and error properties are in order)', () => {
+    let caught = false
+    return open(dbName, 3, upgradeCallback).then((db) => {
+      return del(dbName).catch(function errorCatcher(err) {
+        if (err.type === 'blocked') {
+          // Handle other `err` errors here
+          // expect(err.oldVersion).to.equal(3) // https://bugzilla.mozilla.org/show_bug.cgi?id=1220279
+          expect(err.newVersion).to.be.a('null')
+          if (db) db.close()
+          caught = true
+          return err.resume
+        }
+      }).then(function completedDelete(e) {
+        expect(e.oldVersion).equal(3)
+        expect(e.newVersion).to.be.a('null')
+        expect(caught).equal(true)
+      })
+    })
   })
 
   function upgradeCallback(e) {


### PR DESCRIPTION
…r object;
- Fix: Remove repeated attempt after block event as not working in browser testing;
- Fix: Polyfill delete's `newVersion` for Firefox (and add tests);
- Fix: Polyfill PhantomJS' `del` success event, resumed and otherwise (and add tests);
- Fix: `preventDefault` within error handlers to avoid bubbling of errors beyond `catch`;
- Feature: Support resumption of blocked events via `resume` property (and add docs and tests) (issue #1);
- Feature: Pass on event object to `del` `onsuccess`;
- Testing feature: Separate zuul from local testing;
- Testing: Extend timeout for Firefox;
- Testing: Add delete test (with checks for its success event)
