### PR TITLE
Allow omission of version with supply of upgradeCallback;

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   ],
   "scripts": {
     "prepublish": "babel src --out-dir lib",
-    "test": "eslint src/ test/ && browserify-test -t babelify && SAUCE_USERNAME=idb-factory zuul --tunnel-host http://treojs.com --no-coverage -- test/index.js",
+    "test:local": "eslint src/ test/ && browserify-test -t babelify",
+    "test": "npm run test:local && SAUCE_USERNAME=idb-factory zuul --tunnel-host http://treojs.com --no-coverage -- test/index.js",
     "development": "browserify-test -t babelify --watch"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,9 @@
 export function open(dbName, version, upgradeCallback) {
   return new Promise((resolve, reject) => {
     let isFirst = true
+    if (typeof version === 'function') {
+      upgradeCallback = version
+    }
     const openDb = () => {
       // don't call open with 2 arguments, when version is not set
       const req = version ? idb().open(dbName, version) : idb().open(dbName)


### PR DESCRIPTION
Split test:local

It's handy for testing where you need to check what the latest version is, rather than open a particular version.
